### PR TITLE
Fix scripts not loading in time on slower connections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,14 @@
 <html>
 <head>
   <title>InternetDoesWebsite</title>
-  <script>
-    window.onload = () => {
-      const scripts = ["https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.min.js", "konami-code.js", "script.js"];
-      scripts.forEach(script => {
-        const tag = document.createElement("script");
-        tag.setAttribute("src", script);
-        document.body.appendChild(tag);
-    });
-    }
-  </script>
+
 </head>
 <body>
 
 <h1>Internet Does Website</h1>
 <p>Find out more on the <a href="https://github.com/manuelgu/InternetDoesWebsite">Github page</a></p>
 </body>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.min.js" charset="utf-8" async></script>
+<script src="konami-code.js" charset="utf-8" async></script>
+<script src="script.js" charset="utf-8" async></script>
 </html>


### PR DESCRIPTION
The scripts were not loading in time on a slower connection than
gigabit, causing the browser to trry and execute the scripts before
actually recieving the scripts. There was no visible error in the
console causing some consfusion on why the scripts were not executing.

This commit fixes the matter by removing the async loader and executing
the scripts async using the async modifier in HTML.

To test this commit, load the site on your testing environment and throttle
the connection. this can be done in the Chrome Dev Tools. if the scripts are
loading correctly after a reload, this fix has worked.

Signed-off-by: MegaXLR <admin@megaxlr.net>